### PR TITLE
Handle path command-line argument

### DIFF
--- a/src/shinestacker/app/args_parser_opts.py
+++ b/src/shinestacker/app/args_parser_opts.py
@@ -32,8 +32,16 @@ set top-bottom view.
 def extract_positional_filename():
     positional_filename = None
     filtered_args = []
+    value_flags = {'-p', '--path', '-f', '--filename'}
+    consume_next = False
     for arg in sys.argv[1:]:
-        if not arg.startswith('-') and not positional_filename:
+        if consume_next:
+            filtered_args.append(arg)
+            consume_next = False
+        elif arg in value_flags:
+            filtered_args.append(arg)
+            consume_next = True
+        elif not arg.startswith('-') and not positional_filename:
             positional_filename = arg
         else:
             filtered_args.append(arg)

--- a/src/shinestacker/app/main.py
+++ b/src/shinestacker/app/main.py
@@ -267,6 +267,9 @@ open retouch window at startup instead of project windows.
         else:
             main_app.switch_to_retouch()
             open_frames(main_app.retouch_window, filename, path)
+    elif path:
+        main_app.switch_to_project()
+        QTimer.singleShot(100, lambda: main_app.project_window.new_project(path))
     else:
         retouch = args['retouch']
         if retouch:

--- a/src/shinestacker/gui/folder_file_selection.py
+++ b/src/shinestacker/gui/folder_file_selection.py
@@ -146,5 +146,8 @@ class FolderFileSelectionWidget(QWidget):
     def get_path(self):
         return self.path_edit.text()
 
+    def set_path(self, path):
+        self.path_edit.setText(path)
+
     def text_changed_connect(self, callback):
         self.path_edit.textChanged.connect(callback)

--- a/src/shinestacker/project/main_window.py
+++ b/src/shinestacker/project/main_window.py
@@ -350,12 +350,12 @@ class MainWindow(ProjectHandler, QMainWindow):
         self.selection_state.set_indices()
         self.show_status_message("New project from template.")
 
-    def new_project(self):
+    def new_project(self, path=None):
         if self.check_unsaved_changes():
             os.chdir(get_app_base_path())
             self.reset_project()
             self.update_title()
-            if fill_new_project(self.project(), self):
+            if fill_new_project(self.project(), self, initial_path=path):
                 self.element_action.mark_as_modified()
                 for view in self.views.values():
                     view.clear_project()

--- a/src/shinestacker/project/new_project.py
+++ b/src/shinestacker/project/new_project.py
@@ -21,7 +21,7 @@ DEFAULT_NO_COUNT_LABEL = " - "
 class NewProjectDialog(BaseFormDialog):
     ram_threshold = 4
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, initial_path=None):
         super().__init__("New Project", 600, parent)
         self.expert_widgets = []
         self.expert_labels = []
@@ -30,6 +30,8 @@ class NewProjectDialog(BaseFormDialog):
         self.create_ok_cancel()
         self.n_image_files = 0
         self.selected_filenames = []
+        if initial_path:
+            self.input_widget.set_path(initial_path)
         self.update_expert_visibility()
 
     def expert(self):
@@ -424,9 +426,9 @@ class NewProjectDialog(BaseFormDialog):
         return self.multi_layer.isChecked()
 
 
-def fill_new_project(project, parent):
+def fill_new_project(project, parent, initial_path=None):
     jobs = project.jobs
-    dialog = NewProjectDialog(parent)
+    dialog = NewProjectDialog(parent, initial_path=initial_path)
     if dialog.exec() == QDialog.Accepted:
         input_folder = dialog.get_input_folder()
         working_path = os.path.dirname(input_folder)


### PR DESCRIPTION
According to `shinestacker -h`, there are `-p` and `--path` command line options:
```
  -p [PATH], --path [PATH]
                        import frames from one or more directories. Multiple directories can be
                        specified separated by ';'.
```
But the current `extract_positional_filename` code doesn't take into account that these options take arguments, so it filters out the first argument as a positional filename.  So if you run `shinestacker -p /path/to/folder`, `/path/to/folder` is taken as a positional argument and we end up with `args['path']` being `None`.

The first commit fixes `extract_positional_filename`, but I'm not really happy with this approach.  It requires hard-coding which options take arguments, it doesn't correctly handle the `-p/path/to/folder` and `--path=/path/to/folder` syntaxes (which the parser supports), and is just fragile in general.  The parser already has support for positional arguments, so I wonder if we should get rid of this function and used the built-in support?  I'm also confused by the fact that `extract_positional_filename` only extracts the *first* positional argument and am not sure what happens to the rest or why the first is treated specially.  So maybe we need a bit of discussion to decide how to proceed.  I'll mark this a draft.

The second commit actually makes use of the path argument.  Currently it is never used.  More precisely, there is one spot where it appears, but in that spot it is guaranteed to be None or ''.  This is because earlier it is enforced that only one of `-f` and `-p` is given, and the one place where the path argument is used is within an `if filename` block, so `path` must be falsey here.  So (with some help from Claude; let me know if that's ok) I came up with a way to propagate the `path` argument so that it appears in the new project dialog box.