### PR TITLE
fix: make "retouch after run" setting actually take effect (#56)

### DIFF
--- a/src/shinestacker/classic_project/classic_project_view.py
+++ b/src/shinestacker/classic_project/classic_project_view.py
@@ -184,7 +184,7 @@ class ClassicProjectView(ProjectView, ListContainer):
         retouch_paths = [] if len(r) == 0 else [(job_name, r)]
         new_window, id_str = self.create_new_window(f"{job_name} [Job]",
                                                     labels, retouch_paths)
-        worker = JobLogWorker(job, id_str, self.retouch_after_run)
+        worker = JobLogWorker(job, id_str)
         self.connect_worker_signals(worker, new_window)
         self.start_thread(worker)
         self._workers.append(worker)
@@ -203,7 +203,7 @@ class ClassicProjectView(ProjectView, ListContainer):
                 retouch_paths.append((job.params["name"], r))
         new_window, id_str = self.create_new_window(f"{project_name} [Project]",
                                                     labels, retouch_paths)
-        worker = ProjectLogWorker(self.project(), id_str, self.retouch_after_run)
+        worker = ProjectLogWorker(self.project(), id_str)
         self.connect_worker_signals(worker, new_window)
         self.start_thread(worker)
         self._workers.append(worker)

--- a/src/shinestacker/common_project/project_view.py
+++ b/src/shinestacker/common_project/project_view.py
@@ -6,6 +6,7 @@ from PySide6.QtCore import Signal, Qt
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QWidget, QMenu, QMessageBox
 from .. core.core_utils import running_under_windows, running_under_macos
+from .. config.app_config import AppConfig
 from .. config.constants import constants
 from .. gui.gui_logging import LogManager
 from .. gui.action_config_dialog import ActionConfigDialog
@@ -37,12 +38,8 @@ class ProjectView(QWidget, LogManager, ProjectHandler):
         LogManager.__init__(self)
         self.dark_theme = dark_theme
         self.selection_state = selection_state
-        self.retouch_after_run = False
         self._current_file_name = ''
         self._setup_common_menu_actions()
-
-    def set_retouch_after_run(self, enabled):
-        self.retouch_after_run = enabled
 
     def set_current_file_name(self, file_name):
         self._current_file_name = file_name
@@ -66,7 +63,7 @@ class ProjectView(QWidget, LogManager, ProjectHandler):
         worker.set_total_actions_signal.connect(signal_target.handle_set_total_actions, unique)
         worker.save_plot_signal.connect(signal_target.handle_save_plot, unique)
         worker.open_app_signal.connect(signal_target.handle_open_app, unique)
-        worker.retouch_after_run_signal.connect(self.handle_retouch_after_run, unique)
+        worker.run_completed_signal.connect(self.handle_retouch_after_run, unique)
 
     def _setup_common_menu_actions(self):
         pass
@@ -133,7 +130,7 @@ class ProjectView(QWidget, LogManager, ProjectHandler):
         return True
 
     def handle_retouch_after_run(self, _run_id, _name):
-        if self.retouch_after_run:
+        if AppConfig.get('retouch_after_run'):
             self.run_retouch_selected_job()
 
     def has_run_metadata(self):

--- a/src/shinestacker/common_project/run_worker.py
+++ b/src/shinestacker/common_project/run_worker.py
@@ -25,13 +25,11 @@ class RunWorker(LogWorker):
     add_frame_signal = Signal(str, str, int)
     set_total_actions_signal = Signal(str, str, int)
     update_frame_status_signal = Signal(str, str, int)
-    retouch_after_run_signal = Signal(int, str)
 
-    def __init__(self, id_str, retouch_after_run=False):
+    def __init__(self, id_str):
         LogWorker.__init__(self)
         self.id_str = id_str
         self.status = constants.STATUS_RUNNING
-        self.retouch_after_run = retouch_after_run
         self.callbacks = {
             constants.CALLBACK_BEFORE_ACTION: self.before_action,
             constants.CALLBACK_AFTER_ACTION: self.after_action,
@@ -104,8 +102,6 @@ class RunWorker(LogWorker):
         if status == constants.RUN_COMPLETED:
             message = f"{self.tag} ended successfully"
             self.run_completed_signal.emit(run_id, self.name)
-            if self.retouch_after_run:
-                self.retouch_after_run_signal.emit(run_id, self.name)
             color = COLOR_BLUE
         elif status == constants.RUN_STOPPED:
             message = f"{self.tag} stopped"
@@ -133,8 +129,8 @@ class RunWorker(LogWorker):
 
 
 class JobLogWorker(RunWorker):
-    def __init__(self, job, id_str, retouch_after_run=False):
-        super().__init__(id_str, retouch_after_run)
+    def __init__(self, job, id_str):
+        super().__init__(id_str)
         self.job = job
         self.tag = "Job"
 
@@ -144,8 +140,8 @@ class JobLogWorker(RunWorker):
 
 
 class ProjectLogWorker(RunWorker):
-    def __init__(self, project, id_str, retouch_after_run=False):
-        super().__init__(id_str, retouch_after_run)
+    def __init__(self, project, id_str):
+        super().__init__(id_str)
         self.project = project
         self.tag = "Project"
 

--- a/src/shinestacker/modern_project/modern_project_view.py
+++ b/src/shinestacker/modern_project/modern_project_view.py
@@ -682,14 +682,14 @@ class ModernProjectView(ProjectView):
 
     def _start_job_worker(self, job_index, job):
         self._prepare_job_run_ui(job_index, job)
-        self._worker = JobLogWorker(job, self.last_id_str(), self.retouch_after_run)
+        self._worker = JobLogWorker(job, self.last_id_str())
         self._connect_worker_signals(self._worker)
         self.start_thread(self._worker)
         return True
 
     def _start_project_worker(self):
         self._prepare_project_run_ui()
-        self._worker = ProjectLogWorker(self.project(), self.last_id_str(), self.retouch_after_run)
+        self._worker = ProjectLogWorker(self.project(), self.last_id_str())
         self._connect_worker_signals(self._worker)
         self.start_thread(self._worker)
         return True

--- a/src/shinestacker/project/main_window.py
+++ b/src/shinestacker/project/main_window.py
@@ -183,8 +183,7 @@ class MainWindow(ProjectHandler, QMainWindow):
 
     def toggle_retouch_after_run(self):
         retouch_after_run = self.menu_manager.retouch_after_run_action.isChecked()
-        for view in self.views.values():
-            view.set_retouch_after_run(retouch_after_run)
+        AppConfig.set('retouch_after_run', retouch_after_run)
         self.show_status_message(
             f"Retouch after run {'enabled' if retouch_after_run else 'disabled'}")
 
@@ -467,7 +466,6 @@ class MainWindow(ProjectHandler, QMainWindow):
     def handle_config(self):
         self.menu_manager.expert_options_action.setChecked(
             AppConfig.get('expert_options'))
-        print("retouch after run: ", AppConfig.get('retouch_after_run'))
         self.menu_manager.retouch_after_run_action.setChecked(
             AppConfig.get('retouch_after_run'))
 


### PR DESCRIPTION
Fixes the "run retouch after run" option added in 5a2bfc72 (#56), which never triggered.

## The bug

The flag the workers read lives on the view objects — `ProjectView.retouch_after_run`, initialised to `False`. The only thing that ever writes it is `MainWindow.toggle_retouch_after_run`, which is connected to the menu action's `triggered` signal.

Both places that load the persisted value use `QAction.setChecked()` — in `menu_manager.py` at startup and in `MainWindow.handle_config` when the Settings dialog is accepted. `setChecked()` emits `toggled`, not `triggered`, so `toggle_retouch_after_run` never ran, the views kept `retouch_after_run = False`, and the workers were always constructed with the flag off. The Settings checkbox had no effect in any code path.

Confirmed headless before the fix — the setting is stored correctly, it just never reaches the views:

```
menu action checked: True
classic view.retouch_after_run = False
modern view.retouch_after_run = False
after handle_config: classic False
after handle_config: modern False
```

## The fix

Rather than add the missing propagation call, this removes the duplicated state that made it possible to forget:

- **Read the setting where it is used.** `handle_retouch_after_run` now calls `AppConfig.get('retouch_after_run')` directly. `AppConfig` is a global singleton, so the per-view copy — and the hand-written sync that was missing — is not needed.
- **Reuse the existing completion signal.** `retouch_after_run_signal` was emitted on the line immediately after `run_completed_signal`, with identical `(int, str)` arguments, under a strictly narrower condition, and the receiver re-checked the flag anyway. Hooking `run_completed_signal` instead also removes the `retouch_after_run` parameter threaded through the three worker constructors and their four call sites. `run_completed_signal` is emitted only on `RUN_COMPLETED`, so a stopped or failed run still does not launch retouch.

`run_worker.py`, `classic_project_view.py` and `modern_project_view.py` end up byte-identical to their pre-5a2bfc72 state.

Two smaller fixes in the same area:

- `Run > Retouch After Run` now persists via `AppConfig.set`, mirroring `toggle_expert_options`. Previously it did not, so the menu item and the Settings checkbox could disagree — and because the action started checked (from config) while the views started `False`, the menu item needed **two** clicks to actually enable the feature.
- Removed a leftover `print("retouch after run: ", ...)` debug statement in `handle_config`.

No CHANGELOG entry, since the feature is still in the unreleased `v1.15.x` section and the existing line already describes the intended behaviour.

## Testing

Headless checks against a real `MainWindow`, both views:

```
menu checked at startup: True
classic: retouch launched with flag on=1, extra with flag off=0
modern:  retouch launched with flag on=1, extra with flag off=0
after one click  -> checked: True  config: True
after second click -> checked: False config: False
```

`pytest tests/test_00*.py` — 409 passed.

Also verified interactively on Linux with a single-job project: the stack runs and retouch mode opens automatically.

## One thing this does not address

`handle_retouch_after_run` calls `run_retouch_selected_job()`, which opens the **currently selected** job's output rather than the job that just finished, and shows a "No Job Selected" warning if nothing is selected. That is fine for a single-job project but may open the wrong output after "Run All Jobs". The signal already carries `run_id` and `name`, both currently ignored. Left alone here to keep this a focused fix — happy to follow up if you would like it changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
