### PR TITLE
Alpha-channel support through the focus-stacking pipeline (#69)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ src/shinestacker/_version.py
 logs
 .vscode/
 uv.lock
+
+.venv/
+examples/output/
+examples/plots/
+/output/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,23 @@
 # Changelog
 
 ## [unreleased] - alpha-channel-support branch
-**RGBA / alpha-channel support for the Laplacian pyramid stacker (#69)**
+**RGBA / alpha-channel support for the focus stackers (#69)**
 
 ### Added
-- `PyramidStack` now carries a 4th (alpha) channel through alignment and pyramid
-  fusion. RGBA input frames (16-bit TIFF / PNG) produce an RGBA stacked result.
-  Colour is premultiplied by alpha before the pyramid is built (so transparent
-  regions contribute no focus energy) and un-premultiplied on output.
-- Focus metrics (entropy / deviation / Laplacian energy) are computed from the
-  RGB channels only; the alpha channel follows the same per-pixel frame
-  selection as the colour, so colour and matte never diverge.
-- `AlignFrames`, `denoise` and `unsharp_mask` pass the alpha channel through
-  untouched.
-- Stackers that cannot carry alpha (`DepthMapStack`, `PyramidTilesStack`,
-  `PyramidAutoStack`) now raise a clear error on RGBA input instead of silently
-  dropping the channel.
+- `PyramidStack`, `PyramidTilesStack`, `DepthMapStack` and `PyramidAutoStack`
+  now carry a 4th (alpha) channel through alignment and fusion. RGBA input
+  frames (16-bit TIFF / PNG) produce an RGBA stacked result. Colour is
+  premultiplied by alpha before pyramids are built (so transparent regions
+  contribute no focus energy) and un-premultiplied on output.
+- Focus metrics (entropy / deviation / Laplacian energy / depth-map weights) are
+  computed from the RGB channels only; the alpha channel is fused with the same
+  per-pixel frame selection / weights as the colour, so colour and matte never
+  diverge.
+- `AlignFrames` carries alpha through the warp and forces revealed border area
+  to fully transparent; `BalanceFrames` colour-corrects RGB only; `denoise` and
+  `unsharp_mask` pass alpha through untouched.
+- A stacker that cannot carry alpha (`BaseStackAlgo.supports_alpha = False`)
+  raises a clear error on RGBA input instead of silently dropping the channel.
 - `algorithms.utils`: `has_alpha`, `split_alpha`, `merge_alpha`, `drop_alpha`.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [unreleased] - alpha-channel-support branch
+**RGBA / alpha-channel support for the Laplacian pyramid stacker (#69)**
+
+### Added
+- `PyramidStack` now carries a 4th (alpha) channel through alignment and pyramid
+  fusion. RGBA input frames (16-bit TIFF / PNG) produce an RGBA stacked result.
+  Colour is premultiplied by alpha before the pyramid is built (so transparent
+  regions contribute no focus energy) and un-premultiplied on output.
+- Focus metrics (entropy / deviation / Laplacian energy) are computed from the
+  RGB channels only; the alpha channel follows the same per-pixel frame
+  selection as the colour, so colour and matte never diverge.
+- `AlignFrames`, `denoise` and `unsharp_mask` pass the alpha channel through
+  untouched.
+- Stackers that cannot carry alpha (`DepthMapStack`, `PyramidTilesStack`,
+  `PyramidAutoStack`) now raise a clear error on RGBA input instead of silently
+  dropping the channel.
+- `algorithms.utils`: `has_alpha`, `split_alpha`, `merge_alpha`, `drop_alpha`.
+
+---
+
 ## [v1.16.3] - 2026-08-22
 
 ### Fixed

--- a/src/shinestacker/algorithms/balance.py
+++ b/src/shinestacker/algorithms/balance.py
@@ -12,7 +12,8 @@ from .. core.exceptions import InvalidOptionError
 from .. core.colors import color_str
 from .. core.core_utils import setup_matplotlib_mode
 from .utils import (read_img, img_subsample, bgr_to_hsv, bgr_to_hls,
-                    hsv_to_bgr, hls_to_bgr, bgr_to_lab, lab_to_bgr)
+                    hsv_to_bgr, hls_to_bgr, bgr_to_lab, lab_to_bgr,
+                    split_alpha, merge_alpha, drop_alpha)
 from .stack_framework import SubAction
 setup_matplotlib_mode()
 
@@ -616,7 +617,10 @@ class BalanceFrames(SubAction):
             return
         img = read_img(self.process.input_filepath(process.ref_idx))
         self.shape = img.shape
-        self.correction.begin(img, self.process.total_action_counts, process.ref_idx)
+        # colour balance operates on RGB only; the alpha channel (if any) is
+        # carried through untouched by run_frame().
+        self.correction.begin(drop_alpha(img), self.process.total_action_counts,
+                              process.ref_idx)
 
     def end(self):
         self.process.print_message(' ' * 60)
@@ -636,5 +640,6 @@ class BalanceFrames(SubAction):
             self.process.print_message(
                 color_str(f'{self.process.frame_str(idx)}: balance image',
                           constants.LOG_COLOR_LEVEL_3))
-        image = self.correction.apply_correction(idx, image)
-        return image
+        color, alpha = split_alpha(image)
+        color = self.correction.apply_correction(idx, color)
+        return merge_alpha(color, alpha)

--- a/src/shinestacker/algorithms/base_stack_algo.py
+++ b/src/shinestacker/algorithms/base_stack_algo.py
@@ -7,7 +7,7 @@ from .. core.exceptions import InvalidOptionError, RunStopException
 from .. config.constants import constants
 from .. config.app_config import AppConfig
 from .. core.colors import color_str
-from .utils import read_img, get_img_metadata, get_first_image_file
+from .utils import read_img, get_img_metadata, get_first_image_file, has_alpha
 
 
 class BaseStackAlgo:
@@ -25,6 +25,9 @@ class BaseStackAlgo:
         self.max_pixel_value = None
         self.do_step_callback = False
         self.output_filename = 'undefined'
+        # set in init() from the first input frame; only ever True for
+        # subclasses with supports_alpha = True
+        self.alpha_mode = False
         if float_type == constants.FLOAT_32:
             self.float_type = np.float32
         elif float_type == constants.FLOAT_64:
@@ -61,13 +64,13 @@ class BaseStackAlgo:
         self.filenames = filenames
         first_img = read_img(get_first_image_file(filenames))
         self.shape, self.dtype = get_img_metadata(first_img)
-        if (first_img is not None and first_img.ndim == 3 and first_img.shape[2] == 4
-                and not self.supports_alpha):
+        if has_alpha(first_img) and not self.supports_alpha:
             raise InvalidOptionError(
                 "input", "RGBA image",
                 details=f" the {self._name} algorithm does not carry an alpha "
                         "channel through fusion; use PyramidStack() for RGBA "
                         "input, or drop the alpha channel first")
+        self.alpha_mode = has_alpha(first_img)
         self.num_pixel_values = constants.NUM_UINT8 \
             if self.dtype == np.uint8 else constants.NUM_UINT16
         self.max_pixel_value = constants.MAX_UINT8 \

--- a/src/shinestacker/algorithms/base_stack_algo.py
+++ b/src/shinestacker/algorithms/base_stack_algo.py
@@ -11,6 +11,9 @@ from .utils import read_img, get_img_metadata, get_first_image_file
 
 
 class BaseStackAlgo:
+    # subclasses that carry an alpha channel through fusion set this True
+    supports_alpha = False
+
     def __init__(self, name, steps_per_frame, float_type):
         self._name = name
         self._steps_per_frame = steps_per_frame
@@ -56,7 +59,15 @@ class BaseStackAlgo:
 
     def init(self, filenames):
         self.filenames = filenames
-        self.shape, self.dtype = get_img_metadata(read_img(get_first_image_file(filenames)))
+        first_img = read_img(get_first_image_file(filenames))
+        self.shape, self.dtype = get_img_metadata(first_img)
+        if (first_img is not None and first_img.ndim == 3 and first_img.shape[2] == 4
+                and not self.supports_alpha):
+            raise InvalidOptionError(
+                "input", "RGBA image",
+                details=f" the {self._name} algorithm does not carry an alpha "
+                        "channel through fusion; use PyramidStack() for RGBA "
+                        "input, or drop the alpha channel first")
         self.num_pixel_values = constants.NUM_UINT8 \
             if self.dtype == np.uint8 else constants.NUM_UINT16
         self.max_pixel_value = constants.MAX_UINT8 \

--- a/src/shinestacker/algorithms/denoise.py
+++ b/src/shinestacker/algorithms/denoise.py
@@ -4,6 +4,10 @@ import numpy as np
 
 
 def denoise(image, h_luminance, template_window_size=7, search_window_size=21):
+    if image.ndim == 3 and image.shape[2] == 4:
+        color = denoise(image[..., :3], h_luminance,
+                        template_window_size, search_window_size)
+        return np.concatenate([color, image[..., 3:4]], axis=2)
     norm_type = cv2.NORM_L2 if image.dtype == np.uint8 else cv2.NORM_L1
     if image.dtype == np.uint16:
         h_luminance = h_luminance * 256

--- a/src/shinestacker/algorithms/depth_map.py
+++ b/src/shinestacker/algorithms/depth_map.py
@@ -10,6 +10,8 @@ from .base_stack_algo import BaseStackAlgo, TempDirBase
 
 
 class DepthMapStack(BaseStackAlgo, TempDirBase):
+    supports_alpha = True
+
     def __init__(self, **kwargs):
         default_params = DEFAULTS['depth_map_params']
         focus_stack_params = DEFAULTS['focus_stack_params']
@@ -270,7 +272,8 @@ class DepthMapStack(BaseStackAlgo, TempDirBase):
             w = (w + 1) // 2
             pyramid_shapes_f2c.append((h, w))
         pyramid_shapes_c2f = list(reversed(pyramid_shapes_f2c))
-        blended_pyramid = [np.zeros((*shape, 3), dtype=self.float_type)
+        n_ch = 4 if self.alpha_mode else 3
+        blended_pyramid = [np.zeros((*shape, n_ch), dtype=self.float_type)
                            for shape in pyramid_shapes_c2f]
         weight_pyramid_accum = [np.zeros(shape, dtype=self.float_type)
                                 for shape in pyramid_shapes_c2f]
@@ -293,6 +296,12 @@ class DepthMapStack(BaseStackAlgo, TempDirBase):
                 img_float = img.astype(self.float_type)
                 if img_float.max() > 1.0:
                     img_float = img_float / self.num_pixel_values
+            if self.alpha_mode:
+                # premultiply colour by alpha so transparent regions carry no
+                # colour into the Laplacian pyramid; alpha rides the 4th channel
+                # and is blended with the same per-pixel weights as colour.
+                img_float = img_float.copy()
+                img_float[..., :3] *= img_float[..., 3:4]
             gp_weight, lp_img = self._build_pyramids_for_image(img_float, weight)
             for level in range(self.pyramid_levels):
                 np.multiply(lp_img[level],
@@ -319,6 +328,11 @@ class DepthMapStack(BaseStackAlgo, TempDirBase):
         for level in range(1, self.pyramid_levels):
             size = (blended_pyramid[level].shape[1], blended_pyramid[level].shape[0])
             result = cv2.pyrUp(result, dstsize=size) + blended_pyramid[level]
+        if self.alpha_mode:
+            alpha = np.clip(result[..., 3:4], 0.0, 1.0)
+            floor = 2.0 / 255.0
+            color = np.where(alpha > floor, result[..., :3] / np.maximum(alpha, floor), 0.0)
+            result = np.concatenate([np.clip(color, 0.0, 1.0), alpha], axis=2)
         if self.dtype == np.uint8:
             result = np.clip(result * 255.0, 0, 255).astype(np.uint8)
         elif self.dtype == np.uint16:

--- a/src/shinestacker/algorithms/pyramid.py
+++ b/src/shinestacker/algorithms/pyramid.py
@@ -28,6 +28,7 @@ class PyramidBase(BaseStackAlgo):
         self.max_pixel_value = None
         self.n_levels = 0
         self.n_frames = 0
+        self.alpha_mode = False
 
     def init(self, filenames):
         super().init(filenames)
@@ -103,8 +104,8 @@ class PyramidBase(BaseStackAlgo):
         entropies = np.zeros(images.shape[:3], dtype=self.float_type)
         deviations = np.copy(entropies)
         gray_images = np.array([cv2.cvtColor(
-            images[layer] if self.float_type == np.float32 else
-            images[layer].astype(np.float32),
+            images[layer][..., :3] if self.float_type == np.float32 else
+            images[layer][..., :3].astype(np.float32),
             cv2.COLOR_BGR2GRAY).astype(self.dtype) for layer in range(layers)])
         entropies = np.array([self.entropy(img) for img in gray_images])
         deviations = np.array([self.deviation(img) for img in gray_images])
@@ -133,6 +134,34 @@ class PyramidBase(BaseStackAlgo):
             laplacian.append(pyr - expanded)
         return laplacian
 
+    def premultiply_alpha(self, img):
+        """Split an RGBA frame into premultiplied colour + straight alpha, packed
+        back into a 4-channel float array. Colour is premultiplied so that fully
+        transparent regions carry no colour energy into the Laplacian pyramid
+        (avoids haloing at the matte edge). Sets self.alpha_mode."""
+        if img.ndim == 3 and img.shape[2] == 4:
+            self.alpha_mode = True
+            f = img.astype(self.float_type)
+            a_norm = f[..., 3:4] / self.max_pixel_value
+            color_pm = f[..., :3] * a_norm
+            return np.concatenate([color_pm, f[..., 3:4]], axis=2)
+        return img
+
+    def unpremultiply_alpha(self, img):
+        """Invert premultiply_alpha on the collapsed result: recover straight
+        colour and clip alpha back into range."""
+        if not getattr(self, 'alpha_mode', False):
+            return img
+        f = img.astype(self.float_type)
+        a = np.clip(f[..., 3:4], 0, self.max_pixel_value)
+        a_norm = a / self.max_pixel_value
+        # below ~0.2% coverage the premultiplied colour is dominated by pyramid
+        # ringing / border blur; treat those pixels as fully transparent black.
+        floor = 2.0 / 255.0
+        color = np.where(a_norm > floor, f[..., :3] / np.maximum(a_norm, floor), 0.0)
+        color = np.clip(color, 0, self.max_pixel_value)
+        return np.concatenate([color, a], axis=2)
+
     def fuse_laplacian(self, laplacians_list):
         laplacians = np.stack(laplacians_list, axis=0)
         n_layers, h, w, _ = laplacians.shape
@@ -142,7 +171,7 @@ class PyramidBase(BaseStackAlgo):
             laplacians_32 = laplacians
         energies = np.empty((n_layers, h, w), dtype=np.float32)
         for i in range(n_layers):
-            gray = cv2.cvtColor(laplacians_32[i], cv2.COLOR_BGR2GRAY)
+            gray = cv2.cvtColor(laplacians_32[i][..., :3], cv2.COLOR_BGR2GRAY)
             energies[i] = self.convolve(gray * gray)
         best = np.argmax(energies, axis=0)
         rows = np.arange(h)[:, None]
@@ -152,6 +181,8 @@ class PyramidBase(BaseStackAlgo):
 
 
 class PyramidStack(PyramidBase):
+    supports_alpha = True
+
     def __init__(self, **kwargs):
         super().__init__("pyramid", **kwargs)
         self.offset = np.arange(-self.pad_amount, self.pad_amount + 1)
@@ -188,6 +219,7 @@ class PyramidStack(PyramidBase):
             self.process.callback(constants.CALLBACK_UPDATE_FRAME_STATUS,
                                   self.process.input_path, filename, 200)
             img = read_and_validate_img(img_path, self.shape, self.dtype)
+            img = self.premultiply_alpha(img)
             self.check_running()
             self.print_message(
                 f": processing {self.image_str(i)}")
@@ -204,4 +236,5 @@ class PyramidStack(PyramidBase):
                                   self.process.input_path, filename, 201)
             self.check_running()
         stacked_image = self.collapse(self.fuse_pyramids(all_laplacians))
+        stacked_image = self.unpremultiply_alpha(stacked_image)
         return stacked_image.astype(self.dtype)

--- a/src/shinestacker/algorithms/pyramid.py
+++ b/src/shinestacker/algorithms/pyramid.py
@@ -28,7 +28,6 @@ class PyramidBase(BaseStackAlgo):
         self.max_pixel_value = None
         self.n_levels = 0
         self.n_frames = 0
-        self.alpha_mode = False
 
     def init(self, filenames):
         super().init(filenames)
@@ -138,9 +137,8 @@ class PyramidBase(BaseStackAlgo):
         """Split an RGBA frame into premultiplied colour + straight alpha, packed
         back into a 4-channel float array. Colour is premultiplied so that fully
         transparent regions carry no colour energy into the Laplacian pyramid
-        (avoids haloing at the matte edge). Sets self.alpha_mode."""
-        if img.ndim == 3 and img.shape[2] == 4:
-            self.alpha_mode = True
+        (avoids haloing at the matte edge)."""
+        if self.alpha_mode and img.ndim == 3 and img.shape[2] == 4:
             f = img.astype(self.float_type)
             a_norm = f[..., 3:4] / self.max_pixel_value
             color_pm = f[..., :3] * a_norm

--- a/src/shinestacker/algorithms/pyramid_auto.py
+++ b/src/shinestacker/algorithms/pyramid_auto.py
@@ -12,6 +12,8 @@ from .pyramid_tiles import PyramidTilesStack
 
 
 class PyramidAutoStack(BaseStackAlgo):
+    supports_alpha = True
+
     def __init__(self, **kwargs):
         pyramid_default_params = DEFAULTS['pyramid_params']
         focus_stack_defaults_params = DEFAULTS['focus_stack_params']
@@ -44,6 +46,9 @@ class PyramidAutoStack(BaseStackAlgo):
 
     def init(self, filenames):
         super().init(filenames)
+        if self.alpha_mode:
+            self.channels = 4
+            self.bytes_per_pixel = self.channels * np.dtype(self.float_type).itemsize
         self.n_levels = int(np.log2(min(self.shape) / self.min_size))
         self.n_frames = len(filenames)
         memory_required_memory = self._estimate_memory_memory()

--- a/src/shinestacker/algorithms/pyramid_tiles.py
+++ b/src/shinestacker/algorithms/pyramid_tiles.py
@@ -20,6 +20,8 @@ from .pyramid import PyramidBase
 
 
 class PyramidTilesStack(PyramidBase, TempDirBase):
+    supports_alpha = True
+
     def __init__(self, **kwargs):
         PyramidBase.__init__(self, "fast_pyramid", **kwargs)
         TempDirBase.__init__(self)
@@ -37,6 +39,10 @@ class PyramidTilesStack(PyramidBase, TempDirBase):
         max_threads = kwargs.get('max_threads', focus_stack_defaults_params['max_threads'])
         self.num_threads = max(1, min(max_threads, available_cores))
         self.min_free_space_gb = 5
+
+    @property
+    def n_ch(self):
+        return 4 if self.alpha_mode else 3
 
     def init(self, filenames):
         super().init(filenames)
@@ -57,6 +63,7 @@ class PyramidTilesStack(PyramidBase, TempDirBase):
         return idx, img_path, level_count
 
     def process_single_image(self, img, levels, img_index):
+        img = self.premultiply_alpha(img)
         laplacian = self.single_image_laplacian(img, levels)
         self.level_shapes[img_index] = [level.shape for level in laplacian[::-1]]
         for level_idx, level_data in enumerate(laplacian[::-1]):
@@ -116,7 +123,7 @@ class PyramidTilesStack(PyramidBase, TempDirBase):
                 traceback.print_exc()
 
     def _fuse_level_tiles_serial(self, level, num_images, all_level_counts, h, w, count):
-        fused_level = np.zeros((h, w, 3), dtype=self.float_type)
+        fused_level = np.zeros((h, w, self.n_ch), dtype=self.float_type)
         for y in range(0, h, self.tile_size):
             for x in range(0, w, self.tile_size):
                 y_end, x_end = min(y + self.tile_size, h), min(x + self.tile_size, w)
@@ -138,7 +145,7 @@ class PyramidTilesStack(PyramidBase, TempDirBase):
         return fused_level, count
 
     def _fuse_level_tiles_parallel(self, level, num_images, all_level_counts, h, w, count):
-        fused_level = np.zeros((h, w, 3), dtype=self.float_type)
+        fused_level = np.zeros((h, w, self.n_ch), dtype=self.float_type)
         tiles = []
         for y in range(0, h, self.tile_size):
             for x in range(0, w, self.tile_size):
@@ -192,7 +199,7 @@ class PyramidTilesStack(PyramidBase, TempDirBase):
             y_end = min(y + self.tile_size, h)
             x_end = min(x + self.tile_size, w)
             gc.collect()
-            return np.zeros((y_end - y, x_end - x, 3), dtype=self.float_type)
+            return np.zeros((y_end - y, x_end - x, self.n_ch), dtype=self.float_type)
         except Exception:
             traceback.print_exc()
             self.print_message(color_str(
@@ -313,10 +320,10 @@ class PyramidTilesStack(PyramidBase, TempDirBase):
                             x_end = min(x + self.tile_size, w)
                             tile_height = y_end - y
                             tile_width = x_end - x
-                            tile_size_bytes = tile_height * tile_width * 3 * 4
+                            tile_size_bytes = tile_height * tile_width * self.n_ch * 4
                             processing_size_bytes += tile_size_bytes
                 else:
-                    level_size_bytes = h * w * 3 * 4  # float32
+                    level_size_bytes = h * w * self.n_ch * 4  # float32
                     processing_size_bytes += level_size_bytes
         fusion_size_bytes = 0
         largest_level_size = 0
@@ -331,9 +338,9 @@ class PyramidTilesStack(PyramidBase, TempDirBase):
                         x_end = min(x + self.tile_size, w)
                         tile_height = y_end - y
                         tile_width = x_end - x
-                        tile_size_bytes = tile_height * tile_width * 3 * 4
+                        tile_size_bytes = tile_height * tile_width * self.n_ch * 4
                         level_tiles_size += tile_size_bytes
-            fused_level_size = h * w * 3 * 4
+            fused_level_size = h * w * self.n_ch * 4
             total_level_size = level_tiles_size + fused_level_size
             largest_level_size = max(largest_level_size, total_level_size)
         fusion_size_bytes = largest_level_size
@@ -470,7 +477,8 @@ class PyramidTilesStack(PyramidBase, TempDirBase):
             self.check_running(lambda: None)
             try:
                 fused_pyramid = self.fuse_pyramids(all_level_counts)
-                stacked_image = self.collapse(fused_pyramid).astype(self.dtype)
+                stacked_image = self.collapse(fused_pyramid)
+                stacked_image = self.unpremultiply_alpha(stacked_image).astype(self.dtype)
             except Exception as e:
                 traceback.print_exc()
                 self.process.sub_message_r(color_str(

--- a/src/shinestacker/algorithms/sharpen.py
+++ b/src/shinestacker/algorithms/sharpen.py
@@ -4,6 +4,9 @@ import numpy as np
 
 
 def unsharp_mask(image, radius=1.0, amount=1.0, threshold=0.0):
+    if image.ndim == 3 and image.shape[2] == 4:
+        color = unsharp_mask(image[..., :3], radius, amount, threshold)
+        return np.concatenate([color, image[..., 3:4]], axis=2)
     if image.dtype == np.uint16:
         threshold = threshold * 256
     blurred = cv2.GaussianBlur(image, (0, 0), radius)

--- a/src/shinestacker/algorithms/stack_framework.py
+++ b/src/shinestacker/algorithms/stack_framework.py
@@ -101,7 +101,8 @@ class ImageSequenceManager:
                 filelist = []
                 for _dirpath, _, filenames in os.walk(d):
                     filelist = [os.path.join(_dirpath, name)
-                                for name in filenames if extension_supported_input(name)]
+                                for name in filenames
+                                if extension_supported_input(name) and not name.startswith('.')]
                     filelist.sort()
                     if self.reverse_order:
                         filelist.reverse()

--- a/src/shinestacker/algorithms/transform_estimate.py
+++ b/src/shinestacker/algorithms/transform_estimate.py
@@ -448,4 +448,15 @@ class TransformationExtractor:
             blurred_warp = cv2.GaussianBlur(
                 img_warp, (21, 21), sigmaX=self.alignment_config['border_blur'])
             img_warp[mask == 0] = blurred_warp[mask == 0]
+        if img_warp.ndim == 3 and img_warp.shape[2] == 4:
+            # revealed border area must read as fully transparent, whatever the
+            # colour border mode did there
+            coverage = np.ones(img_0.shape[:2], dtype=np.uint8)
+            if transform_type == constants.ALIGN_HOMOGRAPHY:
+                coverage = cv2.warpPerspective(coverage, m, (w_ref, h_ref),
+                                               borderMode=cv2.BORDER_CONSTANT, borderValue=0)
+            else:
+                coverage = cv2.warpAffine(coverage, m, (w_ref, h_ref),
+                                          borderMode=cv2.BORDER_CONSTANT, borderValue=0)
+            img_warp[..., 3][coverage == 0] = 0
         return img_warp

--- a/src/shinestacker/algorithms/transform_estimate.py
+++ b/src/shinestacker/algorithms/transform_estimate.py
@@ -239,8 +239,8 @@ def rescale_transform(m, w0, h0, w_sub, h_sub, subsample, transform):
 
 def find_transform_phase_correlation(img_ref, img_0):
     if len(img_ref.shape) == 3:
-        ref_gray = cv2.cvtColor(img_ref, cv2.COLOR_BGR2GRAY)
-        mov_gray = cv2.cvtColor(img_0, cv2.COLOR_BGR2GRAY)
+        ref_gray = cv2.cvtColor(img_ref[..., :3], cv2.COLOR_BGR2GRAY)
+        mov_gray = cv2.cvtColor(img_0[..., :3], cv2.COLOR_BGR2GRAY)
     else:
         ref_gray = img_ref
         mov_gray = img_0
@@ -289,8 +289,8 @@ def find_transform_phase_correlation(img_ref, img_0):
         mov_centered = img_0
         scale = 1.0
     if len(img_ref.shape) == 3:
-        ref_gray_trans = cv2.cvtColor(img_ref, cv2.COLOR_BGR2GRAY)
-        mov_gray_trans = cv2.cvtColor(mov_centered, cv2.COLOR_BGR2GRAY)
+        ref_gray_trans = cv2.cvtColor(img_ref[..., :3], cv2.COLOR_BGR2GRAY)
+        mov_gray_trans = cv2.cvtColor(mov_centered[..., :3], cv2.COLOR_BGR2GRAY)
     else:
         ref_gray_trans = img_ref
         mov_gray_trans = mov_centered
@@ -444,7 +444,7 @@ class TransformationExtractor:
         if self.alignment_config['border_mode'] == constants.BORDER_REPLICATE_BLUR:
             if callbacks and 'blur_message' in callbacks:
                 callbacks['blur_message']()
-            mask = cv2.cvtColor(mask, cv2.COLOR_BGR2GRAY)
+            mask = cv2.cvtColor(mask[..., :3], cv2.COLOR_BGR2GRAY)
             blurred_warp = cv2.GaussianBlur(
                 img_warp, (21, 21), sigmaX=self.alignment_config['border_blur'])
             img_warp[mask == 0] = blurred_warp[mask == 0]

--- a/src/shinestacker/algorithms/utils.py
+++ b/src/shinestacker/algorithms/utils.py
@@ -153,7 +153,13 @@ def write_img(file_path, img):
     if extension_jpg(file_path):
         cv2.imwrite(file_path, img, [int(cv2.IMWRITE_JPEG_QUALITY), 100])
     elif extension_tif(file_path):
-        cv2.imwrite(file_path, img, [int(cv2.IMWRITE_TIFF_COMPRESSION), 1])
+        if img.ndim == 3 and img.shape[2] == 4:
+            # Write with ExtraSamples tag so Affinity/Photoshop recognise the alpha channel.
+            # Pyramid stacking un-premultiplies before calling write_img, so alpha is straight.
+            tifffile.imwrite(file_path, img, photometric='rgb', compression='lzw',
+                             extrasamples=['UNASSALPHA'])
+        else:
+            cv2.imwrite(file_path, img, [int(cv2.IMWRITE_TIFF_COMPRESSION), 1])
     elif extension_png(file_path):
         cv2.imwrite(file_path, img, [
             int(cv2.IMWRITE_PNG_COMPRESSION), 9,

--- a/src/shinestacker/algorithms/utils.py
+++ b/src/shinestacker/algorithms/utils.py
@@ -167,17 +167,41 @@ def img_8bit(img):
     return (img >> 8).astype(np.uint8) if img.dtype == np.uint16 else img
 
 
+def has_alpha(img):
+    return img is not None and img.ndim == 3 and img.shape[2] == 4
+
+
+def split_alpha(img):
+    """Return (color, alpha) for a 4-channel image, or (img, None) otherwise."""
+    if has_alpha(img):
+        return img[..., :3], img[..., 3]
+    return img, None
+
+
+def merge_alpha(color, alpha):
+    """Re-attach an alpha channel; alpha may be (h, w) or (h, w, 1)."""
+    if alpha is None:
+        return color
+    if alpha.ndim == 2:
+        alpha = alpha[..., np.newaxis]
+    return np.concatenate([color[..., :3], alpha.astype(color.dtype)], axis=2)
+
+
+def drop_alpha(img):
+    return img[..., :3] if has_alpha(img) else img
+
+
 def img_bw_8bit(img):
     img = img_8bit(img)
     if len(img.shape) == 3:
-        return cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        return cv2.cvtColor(drop_alpha(img), cv2.COLOR_BGR2GRAY)
     if len(img.shape) == 2:
         return img
     raise ValueError(f"Unsupported image format: {img.shape}")
 
 
 def img_bw(img):
-    return cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+    return cv2.cvtColor(drop_alpha(img), cv2.COLOR_BGR2GRAY)
 
 
 def get_first_image_file(filenames):

--- a/tests/test_0063_pyramid_alpha.py
+++ b/tests/test_0063_pyramid_alpha.py
@@ -1,0 +1,164 @@
+"""RGBA / alpha-channel support for the Laplacian pyramid focus stacker.
+
+A synthetic focus stack of a semi-transparent disc: the disc's sharp-focus
+frame varies across the stack, and a soft alpha edge is constant. We check
+that the stacked result:
+  * keeps 4 channels,
+  * has opaque centre / transparent background / a fractional edge band,
+  * picks colour from the in-focus frame inside the disc.
+"""
+import numpy as np
+import cv2
+import pytest
+
+from shinestacker.algorithms.stack_framework import StackJob
+from shinestacker.algorithms.stack import FocusStack
+from shinestacker.algorithms.pyramid import PyramidStack
+from shinestacker.algorithms.utils import read_img, has_alpha
+
+H = W = 256
+MAXV = 65535
+
+
+def _radial(cx, cy):
+    yy, xx = np.mgrid[0:H, 0:W]
+    return np.sqrt((xx - cx) ** 2 + (yy - cy) ** 2)
+
+
+def _alpha_disc():
+    r = _radial(W / 2, H / 2)
+    a = np.clip((70.0 - r) / 12.0, 0.0, 1.0)          # soft edge around r=64
+    return (a * MAXV).astype(np.uint16)
+
+
+def _make_frame(sharp: bool, tint):
+    """A textured disc; `sharp` controls whether the texture is crisp or blurred."""
+    rng = np.random.default_rng(0)
+    texture = rng.integers(0, MAXV, size=(H, W), dtype=np.uint16)
+    bgr = np.stack([np.full((H, W), t, np.uint16) for t in tint], axis=2)
+    bgr = (bgr.astype(np.float64) * 0.6 + texture[..., None].astype(np.float64) * 0.4)
+    bgr = bgr.astype(np.uint16)
+    if not sharp:
+        bgr = cv2.GaussianBlur(bgr, (0, 0), 3)
+    alpha = _alpha_disc()
+    return np.concatenate([bgr, alpha[..., None]], axis=2)
+
+
+@pytest.fixture
+def rgba_stack(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    # frame 0 sharp (blue tint), frame 1 blurred, frame 2 sharp too but we make
+    # frame 1 the only sharp one in a sub-region to force a real selection.
+    frames = [
+        _make_frame(sharp=True, tint=(60000, 8000, 8000)),
+        _make_frame(sharp=False, tint=(8000, 60000, 8000)),
+        _make_frame(sharp=False, tint=(8000, 8000, 60000)),
+    ]
+    for i, f in enumerate(frames):
+        cv2.imwrite(str(src / f"f{i:02d}.tif"), f,
+                    [int(cv2.IMWRITE_TIFF_COMPRESSION), 1])
+    return tmp_path, src
+
+
+def _run(tmp_path, src):
+    job = StackJob("job", str(tmp_path), input_path="src")
+    job.add_action(FocusStack("stk", PyramidStack(), output_path="out",
+                              prefix="s_"))
+    job.run()
+    outs = list((tmp_path / "out").glob("*.tif"))
+    assert len(outs) == 1
+    return read_img(str(outs[0]))
+
+
+def test_output_keeps_alpha(rgba_stack):
+    tmp_path, src = rgba_stack
+    out = _run(tmp_path, src)
+    assert has_alpha(out), f"expected 4 channels, got shape {out.shape}"
+    assert out.dtype == np.uint16
+
+
+def test_alpha_regions(rgba_stack):
+    tmp_path, src = rgba_stack
+    out = _run(tmp_path, src)
+    alpha = out[..., 3].astype(np.float64) / MAXV
+    # centre opaque
+    assert alpha[H // 2, W // 2] > 0.98
+    # far corner transparent
+    assert alpha[5, 5] < 0.02
+    # a fractional band exists near the disc edge
+    band = alpha[(alpha > 0.05) & (alpha < 0.95)]
+    assert band.size > 200
+
+
+def test_no_background_colour_bleed(rgba_stack):
+    tmp_path, src = rgba_stack
+    out = _run(tmp_path, src)
+    alpha = out[..., 3].astype(np.float64) / MAXV
+    bgr = out[..., :3].astype(np.float64)
+    # where fully transparent, straight colour should be ~0 (un-premultiplied)
+    transparent = alpha < 0.01
+    assert bgr[transparent].mean() < 0.02 * MAXV
+
+
+def test_align_then_stack_rgba(tmp_path):
+    """AlignFrames must carry the 4th channel through the warp, and the
+    subsequent pyramid stack must still emit RGBA."""
+    from shinestacker.algorithms.stack_framework import CombinedActions
+    from shinestacker.algorithms.align import AlignFrames
+
+    src = tmp_path / "src"
+    src.mkdir()
+    base = _make_frame(sharp=True, tint=(40000, 20000, 20000))
+    shifts = [(0, 0), (3, -2), (-2, 4)]
+    for i, (dx, dy) in enumerate(shifts):
+        M = np.float32([[1, 0, dx], [0, 1, dy]])
+        shifted = cv2.warpAffine(base, M, (W, H), borderMode=cv2.BORDER_REFLECT101)
+        cv2.imwrite(str(src / f"f{i:02d}.tif"), shifted,
+                    [int(cv2.IMWRITE_TIFF_COMPRESSION), 1])
+
+    job = StackJob("job", str(tmp_path), input_path="src")
+    job.add_action(CombinedActions("align", [AlignFrames()], output_path="aligned"))
+    job.add_action(FocusStack("stk", PyramidStack(), input_path="aligned",
+                              output_path="out"))
+    job.run()
+
+    aligned = read_img(str(next((tmp_path / "aligned").glob("*.tif"))))
+    assert has_alpha(aligned), "align dropped the alpha channel"
+    out = read_img(str(next((tmp_path / "out").glob("*.tif"))))
+    assert has_alpha(out)
+
+
+def test_reference_rgb_only_stack_still_3ch(tmp_path):
+    """Regression: plain RGB stacks are untouched by the alpha path."""
+    src = tmp_path / "src"
+    src.mkdir()
+    rng = np.random.default_rng(1)
+    for i in range(3):
+        img = rng.integers(0, 255, size=(128, 128, 3), dtype=np.uint8)
+        cv2.imwrite(str(src / f"f{i}.tif"), img,
+                    [int(cv2.IMWRITE_TIFF_COMPRESSION), 1])
+    job = StackJob("job", str(tmp_path), input_path="src")
+    job.add_action(FocusStack("stk", PyramidStack(), output_path="out"))
+    job.run()
+    out = read_img(str(next((tmp_path / "out").glob("*.tif"))))
+    assert out.ndim == 3 and out.shape[2] == 3
+
+
+def test_rgba_rejected_by_non_alpha_stackers(rgba_stack):
+    """DepthMap / tiled pyramid must fail loudly on RGBA, not silently drop it."""
+    from shinestacker.algorithms.depth_map import DepthMapStack
+    from shinestacker.algorithms.pyramid_tiles import PyramidTilesStack
+    from shinestacker.core.exceptions import InvalidOptionError
+
+    tmp_path, src = rgba_stack
+    for algo in (DepthMapStack, PyramidTilesStack):
+        job = StackJob("job", str(tmp_path), input_path="src")
+        job.add_action(FocusStack("stk", algo(), output_path=f"out_{algo.__name__}"))
+        with pytest.raises((InvalidOptionError, RuntimeError)):
+            job.run()
+
+
+if __name__ == "__main__":
+    import subprocess
+    subprocess.run(["pytest", "-q", __file__], check=False)

--- a/tests/test_0063_pyramid_alpha.py
+++ b/tests/test_0063_pyramid_alpha.py
@@ -1,162 +1,171 @@
-"""RGBA / alpha-channel support for the Laplacian pyramid focus stacker.
+"""RGBA / alpha-channel support for the pyramid + depth-map focus stackers.
 
-A synthetic focus stack of a semi-transparent disc: the disc's sharp-focus
-frame varies across the stack, and a soft alpha edge is constant. We check
-that the stacked result:
+A synthetic focus stack of a semi-transparent disc: which frame is in sharp
+focus varies across the stack, the soft alpha edge is constant. We check that
+every alpha-capable stacker produces a result that:
   * keeps 4 channels,
   * has opaque centre / transparent background / a fractional edge band,
+  * carries no straight-colour bleed into fully transparent regions,
   * picks colour from the in-focus frame inside the disc.
 """
 import numpy as np
 import cv2
 import pytest
 
-from shinestacker.algorithms.stack_framework import StackJob
+from shinestacker.algorithms.stack_framework import StackJob, CombinedActions
 from shinestacker.algorithms.stack import FocusStack
+from shinestacker.algorithms.align import AlignFrames
 from shinestacker.algorithms.pyramid import PyramidStack
+from shinestacker.algorithms.pyramid_tiles import PyramidTilesStack
+from shinestacker.algorithms.pyramid_auto import PyramidAutoStack
+from shinestacker.algorithms.depth_map import DepthMapStack
 from shinestacker.algorithms.utils import read_img, has_alpha
 
 H = W = 256
 MAXV = 65535
 
-
-def _radial(cx, cy):
-    yy, xx = np.mgrid[0:H, 0:W]
-    return np.sqrt((xx - cx) ** 2 + (yy - cy) ** 2)
+ALPHA_STACKERS = [
+    pytest.param(lambda: PyramidStack(), id="pyramid"),
+    pytest.param(lambda: PyramidTilesStack(tile_size=96, max_threads=1), id="tiles"),
+    pytest.param(lambda: DepthMapStack(), id="depthmap"),
+    pytest.param(lambda: PyramidAutoStack(), id="auto"),
+]
 
 
 def _alpha_disc():
-    r = _radial(W / 2, H / 2)
-    a = np.clip((70.0 - r) / 12.0, 0.0, 1.0)          # soft edge around r=64
-    return (a * MAXV).astype(np.uint16)
+    yy, xx = np.mgrid[0:H, 0:W]
+    r = np.sqrt((xx - W / 2) ** 2 + (yy - H / 2) ** 2)
+    return (np.clip((70.0 - r) / 12.0, 0.0, 1.0) * MAXV).astype(np.uint16)
 
 
-def _make_frame(sharp: bool, tint):
-    """A textured disc; `sharp` controls whether the texture is crisp or blurred."""
-    rng = np.random.default_rng(0)
+def _make_frame(sharp, tint, seed=0):
+    rng = np.random.default_rng(seed)
     texture = rng.integers(0, MAXV, size=(H, W), dtype=np.uint16)
     bgr = np.stack([np.full((H, W), t, np.uint16) for t in tint], axis=2)
-    bgr = (bgr.astype(np.float64) * 0.6 + texture[..., None].astype(np.float64) * 0.4)
+    bgr = (bgr.astype(np.float64) * 0.5 + texture[..., None].astype(np.float64) * 0.5)
     bgr = bgr.astype(np.uint16)
     if not sharp:
         bgr = cv2.GaussianBlur(bgr, (0, 0), 3)
-    alpha = _alpha_disc()
-    return np.concatenate([bgr, alpha[..., None]], axis=2)
+    return np.concatenate([bgr, _alpha_disc()[..., None]], axis=2)
 
 
 @pytest.fixture
-def rgba_stack(tmp_path):
+def rgba_src(tmp_path):
     src = tmp_path / "src"
     src.mkdir()
-    # frame 0 sharp (blue tint), frame 1 blurred, frame 2 sharp too but we make
-    # frame 1 the only sharp one in a sub-region to force a real selection.
+    # only frame 1 is sharp -> its (green) colour should win inside the disc
     frames = [
-        _make_frame(sharp=True, tint=(60000, 8000, 8000)),
-        _make_frame(sharp=False, tint=(8000, 60000, 8000)),
-        _make_frame(sharp=False, tint=(8000, 8000, 60000)),
+        _make_frame(sharp=False, tint=(60000, 8000, 8000), seed=1),
+        _make_frame(sharp=True, tint=(8000, 60000, 8000), seed=2),
+        _make_frame(sharp=False, tint=(8000, 8000, 60000), seed=3),
     ]
     for i, f in enumerate(frames):
-        cv2.imwrite(str(src / f"f{i:02d}.tif"), f,
-                    [int(cv2.IMWRITE_TIFF_COMPRESSION), 1])
-    return tmp_path, src
+        cv2.imwrite(str(src / f"f{i:02d}.tif"), f, [int(cv2.IMWRITE_TIFF_COMPRESSION), 1])
+    return tmp_path
 
 
-def _run(tmp_path, src):
-    job = StackJob("job", str(tmp_path), input_path="src")
-    job.add_action(FocusStack("stk", PyramidStack(), output_path="out",
-                              prefix="s_"))
+def _run(tmp_path, make_algo, input_path="src"):
+    job = StackJob("job", str(tmp_path), input_path=input_path)
+    job.add_action(FocusStack("stk", make_algo(), output_path="out", prefix="s_"))
     job.run()
     outs = list((tmp_path / "out").glob("*.tif"))
     assert len(outs) == 1
     return read_img(str(outs[0]))
 
 
-def test_output_keeps_alpha(rgba_stack):
-    tmp_path, src = rgba_stack
-    out = _run(tmp_path, src)
-    assert has_alpha(out), f"expected 4 channels, got shape {out.shape}"
+@pytest.mark.parametrize("make_algo", ALPHA_STACKERS)
+def test_output_keeps_alpha(rgba_src, make_algo):
+    out = _run(rgba_src, make_algo)
+    assert has_alpha(out), f"expected 4 channels, got {out.shape}"
     assert out.dtype == np.uint16
 
 
-def test_alpha_regions(rgba_stack):
-    tmp_path, src = rgba_stack
-    out = _run(tmp_path, src)
-    alpha = out[..., 3].astype(np.float64) / MAXV
-    # centre opaque
-    assert alpha[H // 2, W // 2] > 0.98
-    # far corner transparent
-    assert alpha[5, 5] < 0.02
-    # a fractional band exists near the disc edge
-    band = alpha[(alpha > 0.05) & (alpha < 0.95)]
-    assert band.size > 200
+@pytest.mark.parametrize("make_algo", ALPHA_STACKERS)
+def test_alpha_regions(rgba_src, make_algo):
+    out = _run(rgba_src, make_algo)
+    a = out[..., 3].astype(np.float64) / MAXV
+    assert a[H // 2, W // 2] > 0.98            # centre opaque
+    assert a[5, 5] < 0.02                      # corner transparent
+    assert a[(a > 0.05) & (a < 0.95)].size > 200   # fractional edge band
 
 
-def test_no_background_colour_bleed(rgba_stack):
-    tmp_path, src = rgba_stack
-    out = _run(tmp_path, src)
-    alpha = out[..., 3].astype(np.float64) / MAXV
+@pytest.mark.parametrize("make_algo", ALPHA_STACKERS)
+def test_no_transparent_colour_bleed(rgba_src, make_algo):
+    out = _run(rgba_src, make_algo)
+    a = out[..., 3].astype(np.float64) / MAXV
     bgr = out[..., :3].astype(np.float64)
-    # where fully transparent, straight colour should be ~0 (un-premultiplied)
-    transparent = alpha < 0.01
-    assert bgr[transparent].mean() < 0.02 * MAXV
+    assert bgr[a < 0.01].mean() < 0.02 * MAXV
 
 
-def test_align_then_stack_rgba(tmp_path):
-    """AlignFrames must carry the 4th channel through the warp, and the
-    subsequent pyramid stack must still emit RGBA."""
-    from shinestacker.algorithms.stack_framework import CombinedActions
-    from shinestacker.algorithms.align import AlignFrames
+@pytest.mark.parametrize("make_algo", ALPHA_STACKERS)
+def test_alpha_follows_focus_selection(rgba_src, make_algo):
+    """Inside the disc the sharp (green) frame should dominate the result."""
+    out = _run(rgba_src, make_algo)
+    c = out[H // 2, W // 2, :3].astype(float)   # BGR
+    assert c[1] > c[0] and c[1] > c[2]
 
+
+@pytest.mark.parametrize("make_algo", ALPHA_STACKERS)
+def test_align_then_stack_rgba(tmp_path, make_algo):
     src = tmp_path / "src"
     src.mkdir()
-    base = _make_frame(sharp=True, tint=(40000, 20000, 20000))
-    shifts = [(0, 0), (3, -2), (-2, 4)]
-    for i, (dx, dy) in enumerate(shifts):
+    base = _make_frame(sharp=True, tint=(40000, 20000, 20000), seed=7)
+    for i, (dx, dy) in enumerate([(0, 0), (3, -2), (-2, 4)]):
         M = np.float32([[1, 0, dx], [0, 1, dy]])
-        shifted = cv2.warpAffine(base, M, (W, H), borderMode=cv2.BORDER_REFLECT101)
-        cv2.imwrite(str(src / f"f{i:02d}.tif"), shifted,
+        cv2.imwrite(str(src / f"f{i:02d}.tif"),
+                    cv2.warpAffine(base, M, (W, H), borderMode=cv2.BORDER_REFLECT101),
                     [int(cv2.IMWRITE_TIFF_COMPRESSION), 1])
-
     job = StackJob("job", str(tmp_path), input_path="src")
     job.add_action(CombinedActions("align", [AlignFrames()], output_path="aligned"))
-    job.add_action(FocusStack("stk", PyramidStack(), input_path="aligned",
-                              output_path="out"))
+    job.add_action(FocusStack("stk", make_algo(), input_path="aligned", output_path="out"))
     job.run()
-
     aligned = read_img(str(next((tmp_path / "aligned").glob("*.tif"))))
     assert has_alpha(aligned), "align dropped the alpha channel"
-    out = read_img(str(next((tmp_path / "out").glob("*.tif"))))
-    assert has_alpha(out)
+    assert has_alpha(read_img(str(next((tmp_path / "out").glob("*.tif")))))
 
 
-def test_reference_rgb_only_stack_still_3ch(tmp_path):
-    """Regression: plain RGB stacks are untouched by the alpha path."""
+def test_align_balance_rgba(tmp_path):
+    """BalanceFrames must colour-correct RGB only and pass alpha through."""
+    from shinestacker.algorithms.balance import BalanceFrames
+    from shinestacker.config.constants import constants
+    src = tmp_path / "src"
+    src.mkdir()
+    for i in range(3):
+        f = _make_frame(sharp=True, tint=(30000 + i * 6000, 30000, 30000 - i * 4000), seed=i)
+        cv2.imwrite(str(src / f"f{i:02d}.tif"), f, [int(cv2.IMWRITE_TIFF_COMPRESSION), 1])
+    job = StackJob("job", str(tmp_path), input_path="src")
+    job.add_action(CombinedActions(
+        "align", [AlignFrames(), BalanceFrames(channel=constants.BALANCE_RGB)],
+        output_path="aligned"))
+    job.run()
+    for p in (tmp_path / "aligned").glob("*.tif"):
+        assert has_alpha(read_img(str(p)))
+
+
+def test_reference_rgb_only_untouched(tmp_path):
+    """Plain RGB stacks still emit 3 channels."""
     src = tmp_path / "src"
     src.mkdir()
     rng = np.random.default_rng(1)
     for i in range(3):
-        img = rng.integers(0, 255, size=(128, 128, 3), dtype=np.uint8)
-        cv2.imwrite(str(src / f"f{i}.tif"), img,
+        cv2.imwrite(str(src / f"f{i}.tif"),
+                    rng.integers(0, 255, (128, 128, 3), np.uint8),
                     [int(cv2.IMWRITE_TIFF_COMPRESSION), 1])
-    job = StackJob("job", str(tmp_path), input_path="src")
-    job.add_action(FocusStack("stk", PyramidStack(), output_path="out"))
-    job.run()
-    out = read_img(str(next((tmp_path / "out").glob("*.tif"))))
+    out = _run(tmp_path, lambda: PyramidStack())
     assert out.ndim == 3 and out.shape[2] == 3
 
 
-def test_rgba_rejected_by_non_alpha_stackers(rgba_stack):
-    """DepthMap / tiled pyramid must fail loudly on RGBA, not silently drop it."""
-    from shinestacker.algorithms.depth_map import DepthMapStack
-    from shinestacker.algorithms.pyramid_tiles import PyramidTilesStack
+def test_non_alpha_algo_rejects_rgba(rgba_src):
+    """A stacker with supports_alpha = False must fail loudly, not drop alpha."""
     from shinestacker.core.exceptions import InvalidOptionError
 
-    tmp_path, src = rgba_stack
-    for algo in (DepthMapStack, PyramidTilesStack):
-        job = StackJob("job", str(tmp_path), input_path="src")
-        job.add_action(FocusStack("stk", algo(), output_path=f"out_{algo.__name__}"))
-        with pytest.raises((InvalidOptionError, RuntimeError)):
-            job.run()
+    class NoAlphaPyramid(PyramidStack):
+        supports_alpha = False
+
+    job = StackJob("job", str(rgba_src), input_path="src")
+    job.add_action(FocusStack("stk", NoAlphaPyramid(), output_path="out"))
+    with pytest.raises((InvalidOptionError, RuntimeError)):
+        job.run()
 
 
 if __name__ == "__main__":

--- a/tools/rgba_stack.py
+++ b/tools/rgba_stack.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""End-to-end RGBA focus-stack test harness for the alpha-channel fork.
+
+Takes a folder of focus-stack frames, attaches an alpha matte to each, runs
+AlignFrames + a stacker, and writes the RGBA result plus a checkerboard-
+composite preview so you can eyeball the matte edge.
+
+Matte source (--matte):
+  folder:<dir>   per-frame masks in <dir> (matched by sorted order); white=opaque
+  const:<dir>    a single mask image in <dir>, reused for every frame
+  luma:<lo>,<hi> threshold the frame luminance, soft-ramp between lo..hi (0-255)
+  rembg          use rembg (birefnet-general) if installed
+
+Examples:
+  python tools/rgba_stack.py ~/pics/bug_angle01 --matte luma:35,60 --stacker pyramid
+  python tools/rgba_stack.py in/ --matte const:mattes/ --stacker depthmap -o out/
+"""
+import argparse
+import glob
+import os
+import sys
+import shutil
+
+import numpy as np
+import cv2
+
+from shinestacker.algorithms.stack_framework import StackJob, CombinedActions
+from shinestacker.algorithms.align import AlignFrames
+from shinestacker.algorithms.stack import FocusStack
+from shinestacker.algorithms.pyramid import PyramidStack
+from shinestacker.algorithms.pyramid_tiles import PyramidTilesStack
+from shinestacker.algorithms.pyramid_auto import PyramidAutoStack
+from shinestacker.algorithms.depth_map import DepthMapStack
+from shinestacker.algorithms.utils import read_img, has_alpha
+
+STACKERS = {
+    "pyramid": lambda: PyramidStack(),
+    "tiles": lambda: PyramidTilesStack(),
+    "depthmap": lambda: DepthMapStack(),
+    "auto": lambda: PyramidAutoStack(),
+}
+EXTS = ("*.tif", "*.tiff", "*.png", "*.jpg", "*.jpeg",
+        "*.dng", "*.cr2", "*.cr3", "*.nef", "*.arw", "*.rw2", "*.orf")
+
+
+def list_images(folder):
+    files = []
+    for e in EXTS:
+        files += glob.glob(os.path.join(folder, e))
+        files += glob.glob(os.path.join(folder, e.upper()))
+    return sorted(set(files))
+
+
+def to_u16(img):
+    if img.dtype == np.uint16:
+        return img
+    if img.dtype == np.uint8:
+        return (img.astype(np.uint16) * 257)
+    return np.clip(img, 0, 1).astype(np.float32).__mul__(65535).astype(np.uint16)
+
+
+def luma_matte(bgr_u16, lo, hi):
+    g = cv2.cvtColor(bgr_u16, cv2.COLOR_BGR2GRAY).astype(np.float32) / 65535.0
+    a = np.clip((g - lo / 255.0) / max(1e-6, (hi - lo) / 255.0), 0, 1)
+    return (a * 65535).astype(np.uint16)
+
+
+def load_mask(path, shape_hw):
+    m = cv2.imread(path, cv2.IMREAD_UNCHANGED)
+    if m is None:
+        sys.exit(f"cannot read mask {path}")
+    if m.ndim == 3:
+        m = m[..., 3] if m.shape[2] == 4 else cv2.cvtColor(m, cv2.COLOR_BGR2GRAY)
+    if m.shape[:2] != shape_hw:
+        m = cv2.resize(m, (shape_hw[1], shape_hw[0]), interpolation=cv2.INTER_LINEAR)
+    return to_u16(m)
+
+
+def rembg_matte(bgr_u16):
+    try:
+        from rembg import remove, new_session
+    except ImportError:
+        sys.exit("rembg not installed:  pip install rembg onnxruntime")
+    sess = new_session("birefnet-general")
+    rgb8 = cv2.cvtColor((bgr_u16 >> 8).astype(np.uint8), cv2.COLOR_BGR2RGB)
+    out = remove(rgb8, session=sess)  # RGBA
+    return to_u16(out[..., 3])
+
+
+def build_rgba(src_files, matte_spec, work_src):
+    os.makedirs(work_src, exist_ok=True)
+    mask_files = None
+    const_mask = None
+    if matte_spec.startswith("folder:"):
+        mask_files = list_images(matte_spec.split(":", 1)[1])
+        if len(mask_files) != len(src_files):
+            sys.exit(f"{len(mask_files)} masks for {len(src_files)} frames")
+    elif matte_spec.startswith("const:"):
+        cm = list_images(matte_spec.split(":", 1)[1])
+        if not cm:
+            sys.exit("no mask found for const: matte")
+        const_mask = cm[0]
+
+    for i, f in enumerate(src_files):
+        bgr = to_u16(read_img(f))[..., :3]
+        if mask_files:
+            a = load_mask(mask_files[i], bgr.shape[:2])
+        elif const_mask:
+            a = load_mask(const_mask, bgr.shape[:2])
+        elif matte_spec.startswith("luma:"):
+            lo, hi = (float(x) for x in matte_spec.split(":", 1)[1].split(","))
+            a = luma_matte(bgr, lo, hi)
+        elif matte_spec == "rembg":
+            a = rembg_matte(bgr)
+        else:
+            sys.exit(f"unknown --matte {matte_spec}")
+        rgba = np.concatenate([bgr, a[..., None]], axis=2)
+        cv2.imwrite(os.path.join(work_src, f"f{i:04d}.tif"), rgba,
+                    [int(cv2.IMWRITE_TIFF_COMPRESSION), 1])
+    print(f"wrote {len(src_files)} RGBA frames -> {work_src}")
+
+
+def checkerboard_preview(rgba, path, sq=24):
+    prev = (rgba[..., :3] >> 8).astype(np.uint8)
+    a = rgba[..., 3:4].astype(np.float32) / 65535.0
+    ch = (np.indices(rgba.shape[:2]).sum(0) // sq) % 2
+    bg = np.where(ch[..., None] == 0, 190, 130).astype(np.uint8)
+    cv2.imwrite(path, (prev * a + bg * (1 - a)).astype(np.uint8))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("src", help="folder of focus-stack frames")
+    ap.add_argument("--matte", required=True,
+                    help="folder:<dir> | const:<dir> | luma:<lo>,<hi> | rembg")
+    ap.add_argument("--stacker", default="pyramid", choices=list(STACKERS))
+    ap.add_argument("--no-align", action="store_true", help="skip AlignFrames")
+    ap.add_argument("-o", "--out", default=None, help="output folder (default: <src>/rgba_out)")
+    args = ap.parse_args()
+
+    src_files = list_images(args.src)
+    if len(src_files) < 2:
+        sys.exit(f"need >=2 frames in {args.src}, found {len(src_files)}")
+    print(f"{len(src_files)} source frames")
+
+    out_dir = args.out or os.path.join(args.src, "rgba_out")
+    work = os.path.join(out_dir, "_work")
+    shutil.rmtree(work, ignore_errors=True)
+    os.makedirs(out_dir, exist_ok=True)
+
+    build_rgba(src_files, args.matte, os.path.join(work, "src"))
+
+    job = StackJob("rgba", work, input_path="src")
+    stack_input = "src"
+    if not args.no_align:
+        job.add_action(CombinedActions("align", [AlignFrames()], output_path="aligned"))
+        stack_input = "aligned"
+    job.add_action(FocusStack("stack", STACKERS[args.stacker](),
+                              input_path=stack_input, output_path="stacked"))
+    job.run()
+
+    result_path = next(iter(glob.glob(os.path.join(work, "stacked", "*.tif"))), None)
+    if result_path is None:
+        sys.exit("no stacked output produced")
+    rgba = read_img(result_path)
+    final = os.path.join(out_dir, f"stacked_{args.stacker}.tif")
+    shutil.copy(result_path, final)
+    checkerboard_preview(rgba, os.path.join(out_dir, f"preview_{args.stacker}.png"))
+
+    a = rgba[..., 3].astype(np.float32) / 65535.0
+    print(f"\nresult: {rgba.shape} {rgba.dtype}  has_alpha={has_alpha(rgba)}")
+    print(f"  alpha: opaque {(a > 0.98).mean():.1%}  transparent {(a < 0.02).mean():.1%}"
+          f"  edge-band {((a > 0.05) & (a < 0.95)).mean():.1%}")
+    if (a < 0.01).any():
+        print(f"  straight RGB mean where transparent: "
+              f"{rgba[..., :3].astype(float)[a < 0.01].mean():.1f} / 65535")
+    print(f"\n  {final}\n  {os.path.join(out_dir, f'preview_{args.stacker}.png')}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#69.

Adds alpha-channel support through the focus-stacking pipeline, so RGBA input
produces RGBA output with the alpha carried through fusion rather than dropped.

### Motivation

Batch focus stacking of pinned insect specimens for photogrammetry / 3DGS. The
subjects are matted against a backdrop first, so every frame is RGBA; previously
the alpha was discarded during fusion and the silhouette had to be rebuilt
afterwards.

### What's included

- **`PyramidStack`** — carries alpha through Laplacian fusion. Algorithms opt in
  via a `supports_alpha` class flag; `init()` raises a clear error if RGBA input
  is given to an algorithm that would silently drop it.
- **Extended to** `PyramidTilesStack`, `PyramidAutoStack`, `DepthMapStack`,
  plus balance and align border handling.
- **`write_img`** — 4-channel TIFFs now go through `tifffile` with
  `photometric='rgb'` and `extrasamples=['UNASSALPHA']`. `cv2.imwrite` does not
  tag the 4th channel, so output opened as opaque in Affinity/Photoshop.
  Straight (un-premultiplied) is correct because the pyramid un-premultiplies
  before writing. 3-channel writes are untouched.
- **`tests/test_0063_pyramid_alpha.py`** — 23 tests covering alpha through each
  stage.
- **`tools/rgba_stack.py`** — end-to-end RGBA harness for manual checks.

### One unrelated commit

`Skip dotfiles when scanning input directories` is not part of #69 — macOS
writes `._name.tif` AppleDouble stubs on external volumes, which carry a
supported extension but are 4KB metadata files and fail to decode. Happy to
drop it into its own PR if you'd rather keep this one focused.

### Testing

- `tests/test_0063_pyramid_alpha.py` — 23 passed
- Full non-GUI suite — 487 passed, no regressions
  (GUI tests not run locally: no PySide6 in this environment)

Also exercised on real data: a 50-frame RGBA stack at 6024x4024, output verified
16-bit RGBA with alpha intact and correct channel order.

### Note on provenance

Much of this was written with AI assistance (Claude Code) and reviewed by me
against real captures. Flagging it so you can weight your review accordingly —
you mentioned wanting to add alpha unit tests at every stage, and the existing
tests here are a starting point rather than exhaustive.
